### PR TITLE
reclaim stack space used in late init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ required-features = ["__v7"]
 
 [dependencies]
 cortex-m = "0.7"
-cortex-m-rtic-macros = "0.5.2"
+cortex-m-rtic-macros = {path = "./macros"}
 rtic-core = "0.3.0"
 cortex-m-rt = "0.6.9"
 heapless = "0.6.0"

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -81,9 +81,17 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
 
                 #(#pre_init_stmts)*
 
-                #call_init
+                #[inline(never)]
+                fn init_late_resources<F>(f: F) where F: FnOnce() {
+                    f();
+                }
 
-                #(#post_init_stmts)*
+                // Wrap late_init_stmts in a function to ensure that stack space is reclaimed.
+                init_late_resources(||{
+                    #call_init
+
+                    #(#post_init_stmts)*
+                });
 
                 #call_idle
             }


### PR DESCRIPTION
With this we save 30KB of ram.  Submitting upstream as well.